### PR TITLE
Added carlseleborg.com to sites.txt

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -13,6 +13,7 @@ ethanleitch.dev
 heonian.org
 blog.movimento-centrale.it
 www.stegriff.co.uk
+carlseleborg.com
 
 # -- end --
 


### PR DESCRIPTION
I hope I followed instructions correctly. Note that my site doesn't support HTTPS at this point, so the correct address is actually http://carlseleborg.com. Thanks for this wonderful project, and for trying to maintain the quirky, personal web of decades past.