### PR TITLE
sites.txt: add blog.reciperadar.com and www.reciperadar.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -115,3 +115,5 @@ arunwadhwa.com
 srijan.ch
 ottomannews.com
 pub.colonq.computer
+blog.reciperadar.com
+www.reciperadar.com


### PR DESCRIPTION
Hello,

RecipeRadar is an AGPLv3-licensed recipe search engine, and this pull request is a request to index two of RecipeRadar's subdomains into your also-AGPLv3-licensed Marginalia web search engine.

The former domain (`blog.reciperadar.com`) is the site's blog, where we share updates about the service and engineering articles.

The latter domain (`www.reciperadar.com`) is the search engine itself, and the anticipated landing page for most users.  The search engine is a single-page application, optionally installable as a Progressive Web Application where supported.

For each subdomain, equivalent content can be retrieved by clients making requests using either HTTP (port 80) or HTTPS (port 443).

Cheers!
James