### PR TITLE
Update sites.txt

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -190,6 +190,15 @@ hidersout.com
 shapesinrealti.me
 www.bumps.cafe
 oddduck.neocities.org
+basspistol.com
+v.basspistol.org
+git.basspistol.org
+do.basspistol.org
+setto.basspistol.com
+paxnion.basspistol.com
+radio.basspistol.com
+txt.basspistol.org
+sakrecoer.com
 blackilykat.dev
 recursewithless.net
 mattstein.com


### PR DESCRIPTION
Adding the list of public basspistol sites.

> Established in 2010 as a pro-active reaction to everything that is broken in the music-industry. Basspistol is an endlessly evolving union for the Underground Artists of the third millenium carrying the values of the Creative Commons. We believe in Music. The underground is dead, Long Live the Underground!