### PR TITLE
Add savalione.com to sites.txt

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -143,6 +143,7 @@ spitlo.com
 blog.plain.technolog
 lunabee.space
 nthia.dev
+savalione.com
 thenitropower.neocities.org
 gonna.surf
 kaiortlieb.com


### PR DESCRIPTION
Hello.
I would like to add my personal blog (savalione.com) to your search engine.
My blog primarily focuses on operating systems, servers, open source tools and programming languages.
Even though new posts are added sporadically, all content is ad-free, original and distributed under a CC-BY license.
Thanks!