### PR TITLE
Add alumni.cottonwoodhigh.school to sites.txt

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -497,6 +497,7 @@ ktibow.github.io
 jade.ellis.link
 jcd.pub
 luke.hsiao.dev
+alumni.cottonwoodhigh.school
 www.opentierboy.com
 opentierboy.com
 ben.companjen.name


### PR DESCRIPTION
This is a community-run, open-source website for alumni/reunion information for a high school. Typically drowned by websites like `{schoolname}.net` from Classmates.com, alumniclass.com, allhighschools.com, or similar in larger search engines.

Seems like a good candidate for Marginalia.