### PR TITLE
Add diskette.ch to the list of sites to crawl

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -655,6 +655,7 @@ kendell.dev
 jade.ellis.link
 jcd.pub
 luke.hsiao.dev
+diskette.ch
 alumni.cottonwoodhigh.school
 www.opentierboy.com
 opentierboy.com


### PR DESCRIPTION
Adding the website for my tiny retro-computing museum in Schaffhausen, Switzerland, to the list of crawlable websites.

Thank you for making and running MarginaliaSearch, it's a wonderful project! :)