### PR TITLE
Add brewpage.app

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -598,6 +598,7 @@ nhobb.com
 autisticasfxxk.com
 monocle-search.com
 godsped.com
+brewpage.app
 blog.neuenet.com
 eplg.services
 emmytherobot.wiki


### PR DESCRIPTION
Submitting brewpage.app for crawling.

BrewPage is a free instant-hosting service for HTML, Markdown, AI artifacts, and small files — public/ namespace contains user-published pages worth indexing.