### PR TITLE
Add alexchernysh.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -638,6 +638,7 @@ mylitjourney.wordpress.com
 dgroshev.com
 blog.waseigo.com
 wilkinson.graphics
+alexchernysh.com
 purserclub.com
 0x85.org
 arunwadhwa.com


### PR DESCRIPTION
Adds alexchernysh.com to sites.txt for Marginalia crawl.

- Personal technical blog (Alex Chernysh) on applied AI systems, retrieval pipelines, and integration architecture.
- Long-form text content, statically pre-rendered (Next.js with SSR), no infinite scroll, no client-side-only routes.
- English content, no ads, no popups.
- Inserted at a middle line (~640) to minimise merge conflict risk per repo guidance.