### PR TITLE
Add deadtools.firstorbit.dev

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -532,6 +532,7 @@ explainxkcd.com
 galaxy.click
 justapa.thologi.st
 balt.sno.mba
+deadtools.firstorbit.dev
 sno.mba
 lilahexe.top
 text.lilahexe.top


### PR DESCRIPTION
Adds deadtools.firstorbit.dev — a small editorial site about replaced or abandoned developer tools — to the crawl list.

The site is text-first, has no JS-required content, and is currently unknown to Marginalia per https://marginalia-search.com/site/deadtools.firstorbit.dev ("Unknown Domain"). robots.txt is wildcard-permissive (User-agent: \*, Allow: /, Disallow: /analyze/), so the search.marginalia.nu crawler is allowed.

Thanks for keeping this list open.