### PR TITLE
Add unlocksaas.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -447,6 +447,7 @@ kanoe.yuuko.eu
 wiki.postmarketos.org
 anita.garden
 postmarketos.org
+unlocksaas.com
 blog.ahiknsr.org
 pocketbook.ch
 godsmercybookshop.com


### PR DESCRIPTION
Adding unlocksaas.com to sites.txt.

UnlockSaaS is founder tooling for indie hackers and solo SaaS founders at the post-launch / pre-revenue stage. Editorial content includes:

- A public glossary of post-launch SaaS terms
- Funnel and pricing teardowns
- Benchmarks for indie SaaS metrics
- A publicly cross-listed dataset on Hugging Face

The site explicitly allow-lists `search.marginalia.nu` in its robots.txt and uses sitemap-driven discovery. No JavaScript-only rendering on canonical pages; content is server-rendered HTML.

Inserted on a random mid-list line per the README's merge-conflict-avoidance guidance.