### PR TITLE
Add www.closingtags.com to sites list

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -245,6 +245,7 @@ maktabquran.com
 www.gotquestions.org
 cmje.org
 asterinas.github.io
+www.closingtags.com
 0x1eef.github.io
 nousresearch.com
 maximilianbenner.com


### PR DESCRIPTION
A new site about web development and adjacent things to be crawled.