### PR TITLE
Add fyndling.de

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -598,6 +598,7 @@ www.stavros.io
 krishadi.com
 nichobi.com
 kypath.sdf.org
+fyndling.de
 tourdeniu.vonneudeck.com
 zwieb.insomnia247.nl
 nhobb.com


### PR DESCRIPTION
Adding fyndling.d: a static, text-first, ad- and tracker-free German site about medieval markets, fairs and historical recipes. No cookie banners, no Google tracking. Pre-rendered HTML pages for event and recipe detail content.