### PR TITLE
Add reykjalin.org to sites list

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -656,6 +656,7 @@ www.bytefish.de
 bouncepaw.com
 jak2k.schwanenberg.name
 garden.bouncepaw.com
+reykjalin.org
 links.bouncepaw.com
 saraf.iwl.pub
 evrim.zone


### PR DESCRIPTION
I recently changed the primary domain for my blog to be https://reykjalin.org. The old domain — https://thorlaksson.com — [is already indexed](https://marginalia-search.com/site/thorlaksson.com?view=info&page=1&sst=SI-45d0541d929fc187).

I intend to keep the old domain indefinitely, so it's probably safe to keep it indexed, but now that reykjalin.org is the primary domain it might be better to start indexing that instead.

I've set up a 301 redirect from the old domain to the new domain — which took a couple tries, so the last indexing of my blog failed 😅 — so if the search index is automatically updated when it's next reindexed then this PR might not even be necessary.

Thank you for maintaining marginalia, it's such a nice part of the web <3