### PR TITLE
Add ipd.bopath.fr

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -1264,6 +1264,7 @@ blogfa.farooqkz.com
 helpme.cash
 blaccat.space
 bitcoincash.network
+ipd.bopath.fr
 flipstarters.bitcoincash.network
 sillon-fictionnel.club
 pvv.ntnu.no


### PR DESCRIPTION
Adds `ipd.bopath.fr` — a Pāli–English dictionary (Bopath IPD), free to read, no ads, no tracking, content under CC BY-NC-SA 4.0. Text-heavy reference material in 9 languages.

Inserted at a random line in `sites.txt` as the readme asks, to avoid merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)