### PR TITLE
Add education and reference sites

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -146,6 +146,7 @@ iraqigreens.net
 www.socialisti.sk
 pcn.org.py
 uppbarbados.org
+schoolnews.com.ng
 aftersummer.net
 securityops.co
 bananapkg.github.io
@@ -170,6 +171,7 @@ kekw.party
 partidopaisparatodos.org.pe
 sartarni.org
 isleofmanfirst.com
+jambsyllabus.com
 booru.neocities.org
 28chan.neocities.org
 skvods.lol
@@ -190,6 +192,7 @@ eatfatchips.com
 lumaeris.com
 aishiteiru.moe
 dcs0.hu
+ukvisapath.com
 npd-voran.de
 spamshit.org
 turtlecute.org
@@ -293,6 +296,7 @@ lists.freebsd.org
 lists.alpinelinux.org
 shatelmobile.ir www.karzar.net
 thecaferobot.com
+humanphenotypes.org
 newtbytes.cc
 synth-ace.proton.gay
 bamprofits.com
@@ -306,6 +310,7 @@ realbitcoin.cash
 sudoshz.ir
 www.dynamicartisan.com
 portal.goeshard.org
+keypoint.ng
 board.goeshard.org
 cashmere.rs
 tylenol.goeshard.org
@@ -426,6 +431,7 @@ tea331.neocities.org
 xoc3.io
 kasilija.neocities.org
 galactipod.neocities.org
+pmhnp-school.com
 sijeni.neocities.org
 manikomtmn.neocities.org
 waso-talu.neocities.org
@@ -595,6 +601,7 @@ stratasource.org
 momentum-mod.org
 blog.momentum-mod.org
 dawnfelstar.com
+zipcodes.ng
 cobb.land
 jacobdensford.com
 alpha.shark.tobot.dev
@@ -602,6 +609,7 @@ dev.shark.tobot.dev
 shark.tobot.dev
 tobot.dev
 www.ausiastsel.com
+currentaffairs.ng
 www.zenodot.app
 paperclipmaximizer.net
 www.2uo.de
@@ -621,6 +629,7 @@ chiroetsn.xyz
 music.nthia.dev
 wolfgirl.dev
 phoki.neocities.org
+townsvillages.com
 skylarhill.me
 gwenpri.me
 www.viblo.se
@@ -643,6 +652,7 @@ nhobb.com
 autisticasfxxk.com
 monocle-search.com
 godsped.com
+waecsyllabus.com
 brewpage.app
 blog.neuenet.com
 eplg.services
@@ -669,6 +679,7 @@ reykjalin.org
 links.bouncepaw.com
 saraf.iwl.pub
 evrim.zone
+icanpathfinder.com
 mycorrhiza.wiki
 betula.mycorrhiza.wiki
 www.jeffrika.com
@@ -701,6 +712,7 @@ www.reciperadar.com
 hazybridge.com
 rowanbird779.nekoweb.org
 bawcast.com
+northwalesminers.com
 zadnyspe.ch
 jentak.co
 mrevil.asvachin.com
@@ -717,6 +729,7 @@ grahameger.com
 regattapages.com
 benlacroix.com
 ass.si
+pianopublicdomain.com
 hidersout.com
 shapesinrealti.me
 www.bumps.cafe
@@ -802,6 +815,7 @@ www.listenfaster.com
 hawksley.dev
 cobycat.neocities.org
 fatbuffalo.neocities.org
+pastquestions.ng
 dvdnerd.neocities.org
 a-blue-in-a-sea-of-reds.neocities.org
 releases.bruta.link
@@ -960,6 +974,7 @@ community.retrospection.xn--q9jyb4c
 szymonnastaly.com
 throwtheproject.com
 stray.video
+crna-school.com
 mirohlichan.net
 alterchan.net
 staffas.org
@@ -1207,6 +1222,7 @@ rayshobby.net
 sagacioussuricata.com
 sakamoto.pl
 scopeboy.com
+waectimetable.com
 sgitheach.org.uk
 silent.org.pl
 slomkowski.eu


### PR DESCRIPTION
Adding a set of reference and education sites I run: exam syllabi/timetables and past questions (Nigeria), nursing-career guides (US), UK visa guides, a UK/Nigeria places gazetteer, public-domain piano scores, human phenotype reference, and a North Wales mining-history archive. Inserted at random lines per the file's instructions.