### PR TITLE
Add astrohours.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -445,6 +445,7 @@ enky.neocities.org
 alignedtrack432.neocities.org
 nasin.nimi.li
 wasona.com
+astrohours.com
 sowelinowe.com
 ggirelli.info
 longevityworldcup.com


### PR DESCRIPTION
Adding `astrohours.com` to `sites.txt`.

Vedic and Western astrology reference site — daily/weekly/monthly horoscopes, birth chart and kundli readings, panchang, nakshatra reference and festival dates, in English, Hindi and Urdu.

Inserted at an interior line (~448) rather than at the end, per the note in `sites.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)