### PR TITLE
Add www.kinkspec.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -835,6 +835,7 @@ www.themanequest.com
 tanookisite.com
 reclaimyour.tech
 ckhollidayplans.com
+https://www.kinkspec.com
 fermi.chat
 blog.fermi.chat
 frockflicks.com


### PR DESCRIPTION
Adding https://www.kinkspec.com — a clinical, non-explicit reference index of kinks, fetishes and paraphilias. Every entry is defined in neutral language, cited to published sources, and placed on a 0-100 index of how common it is.

Static site, no ads, no tracking, no sign-up wall. Inserted mid-list per the note in sites.txt.