### PR TITLE
Add aogavrilov.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -685,6 +685,7 @@ bouncepaw.com
 jak2k.schwanenberg.name
 garden.bouncepaw.com
 reykjalin.org
+aogavrilov.com
 links.bouncepaw.com
 saraf.iwl.pub
 evrim.zone


### PR DESCRIPTION
Adds aogavrilov.com, a static non-commercial academic research site. The site provides crawlable HTML research pages, publication PDFs, robots.txt, sitemap indexes, and RSS/Atom feeds; core content is available without login or JavaScript. This requests inclusion as a crawl seed only and does not assume immediate indexing.