### PR TITLE
Add elnuevocreadortecnico.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -658,6 +658,7 @@ nichobi.com
 kypath.sdf.org
 fyndling.de
 tourdeniu.vonneudeck.com
+elnuevocreadortecnico.com
 zwieb.insomnia247.nl
 nhobb.com
 autisticasfxxk.com


### PR DESCRIPTION
Adds elnuevocreadortecnico.com — a book site available in ten language editions (ES, PT-BR, EN, IT, FR, DE, ID, TR, RU, KO), including freely accessible documentation and free sample PDFs.

The site also contains commercial book information. If this falls outside the project's scope, please feel free to close the PR.

Added on a line in the middle of the file, following the repository guidelines.
