### PR TITLE
Add thebenmeadows.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -740,6 +740,7 @@ www.getlocalcert.net
 grahameger.com
 regattapages.com
 benlacroix.com
+thebenmeadows.com
 ass.si
 pianopublicdomain.com
 hidersout.com


### PR DESCRIPTION
Adding `thebenmeadows.com` — a hand-written static personal site.

No framework, no analytics, no cookies, no third-party requests, and under
100 KB uncompressed for a cold load of the home page. Text-first, with the
same pages also served over Gemini and gopher.

Inserted mid-file rather than appended, per the note at the top of `sites.txt`.