### PR TITLE
Add xylavia.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -1068,6 +1068,7 @@ tintinde7a77ans.free.fr
 hergtintin.free.fr
 sitetintin.chez.com
 fredcrash.com
+xylavia.com
 www.duckiversum.de
 annethology.free.fr
 spinatmaedchen.com


### PR DESCRIPTION
Adding xylavia.com - an original fantasy-world reference wiki and interactive atlas (ad-free, no signups, text-heavy). Inserted at a random line per the file's merge-conflict note.