### PR TITLE
Add cunicula.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -247,6 +247,7 @@ n0p.me
 amin.djawadi.dev
 nghorbani.github.io
 haghiri75.com
+cunicula.com
 haghiri75.com
 ahmadhaghighi.com
 haghiri75.com


### PR DESCRIPTION
Adding https://cunicula.com/ to sites.txt for crawling.

cunicula.com is an independent, non-commercial privacy directory/editorial project (privacy tools, VPN/wallet/hosting vetting, glossary, KYC tracker). No ads, no cookies (per site footer). Has a live RSS feed at https://cunicula.com/feed.xml (77 items, recently updated) and a sitemap.xml. Site states 'a listing is not an endorsement' and publishes its editorial methodology.

Inserted the domain mid-list per the repo's own instructions (not at the beginning or end).