### PR TITLE
Add stackindexai.com and llmpricewatch.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -662,6 +662,8 @@ zwieb.insomnia247.nl
 nhobb.com
 autisticasfxxk.com
 monocle-search.com
+stackindexai.com
+llmpricewatch.com
 godsped.com
 waecsyllabus.com
 brewpage.app


### PR DESCRIPTION
Adding two independent, text-heavy content sites: stackindexai.com (editorial AI/SaaS tool comparisons for solo founders) and llmpricewatch.com (LLM API pricing data + calculator). Both are original, hand-written/data-driven content, no ads.