### PR TITLE
Add dromley.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -308,6 +308,7 @@ wiki.postmarketos.org
 leomax.fyi
 sisoog.com
 ask.sisoog.com
+dromley.com
 bchwebring.com
 chatmail.farooqkz.com
 realbitcoin.cash


### PR DESCRIPTION
Adding dromley.com — a senior-led market intelligence and growth advisory firm, based in India and working with clients across APAC, the Gulf, the UK, Europe and the United States.

Most of the site is reference material rather than marketing copy:

- **Research library** — a continuous publication record from 2017 to 2026, following a single line of enquiry: how people and organisations actually behave — consumer decision-making, technology adoption, organisational behaviour and AI readiness. Methods are declared throughout: chi-square and ANOVA on survey samples, thematic analysis of in-depth interviews, and literature synthesis spanning 2012–2024. Published as peer-reviewed book chapters, a volume with Bloomsbury Publishing India organised around the UN Sustainable Development Goals, an edited volume on AI and sustainability in business, and working papers carrying permanent DOIs.
- **Fundamentals** — a reference layer on business, market-research and growth concepts: definitions, frameworks, methodology and worked distinctions, written for practitioners rather than for search engines.
- **Advisory pages** — write-ups of how specific engagements are approached: the question being answered, the method used, and what gets measured.

Added at a random line mid-file, per the note in sites.txt.