### PR TITLE
Add alexelyukov.ru

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -699,6 +699,7 @@ www.last-outpost.com
 www.lociterm.com
 forwardemail.net
 puffballfungus.neocities.org
+alexelyukov.ru
 bhankas.org
 xnacly.me
 dempewolfapps.com


### PR DESCRIPTION
Adding https://alexelyukov.ru — a personal site of hand-written maths and philosophy. Long-form derivations done properly (Kalman filter, fuzzy logic, vector calculus, Bessel's equation), a set of essays, and two free web books: one on the finite element method, one on lambda calculus, both with interactive figures and a PDF edition.

Server-rendered, no ads, no third-party trackers, no sign-up wall. Russian and English versions (English under /en), RSS at /rss.xml. Inserted mid-list per the note in sites.txt.