### PR TITLE
Add wavect.io

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -39,6 +39,7 @@ lyteforcewrites.fyi
 rss.social
 lumidify.org
 wasi.ovh
+wavect.io
 devitti.bz
 hackaday.com
 treehouse.net


### PR DESCRIPTION
Adds the Wavect GmbH website to the crawl list. The site includes the Apache-2.0 SEMAPRAX pre-alpha programming-language research project at https://wavect.io/semaprax/.