### PR TITLE
Add arirangpost.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -403,6 +403,7 @@ invariance.ceu.su
 nizzlay.com
 ratatoskr.run
 mrtno.com
+arirangpost.com
 bb89.nl
 fragglejazz.nl
 blog.philz.dev


### PR DESCRIPTION
Adding arirangpost.com — an English-language publication of dated, sourced reporting for visitors to Korea (entry rules, transport, events, culture and practical guides). Static HTML, no tracking, sitemap at https://arirangpost.com/sitemap.xml and Atom/RSS feeds at /feed.xml and /rss.xml. Submitted by the site owner. Added on a random line as the readme asks.