### PR TITLE
Add rafaelpfister.ch

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -664,6 +664,7 @@ kypath.sdf.org
 fyndling.de
 tourdeniu.vonneudeck.com
 elnuevocreadortecnico.com
+rafaelpfister.ch
 zwieb.insomnia247.nl
 nhobb.com
 autisticasfxxk.com


### PR DESCRIPTION
Adding rafaelpfister.ch — personal site and blog (in German) about SMTP, mail gateways and email security.