### PR TITLE
Add cosmyday.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -832,6 +832,7 @@ lovelydumpling.nekoweb.org
 mopacic.net
 mcpar.land
 ziit.app
+cosmyday.com
 graphicalmethods.com
 redterminal.org
 www.listenfaster.com


### PR DESCRIPTION
Adding cosmyday.com to sites.txt.

It is a free astrology site: natal chart and compatibility calculators, horoscopes, and retrograde/moon/eclipse calendars, all computed from the Swiss Ephemeris rather than copied from other sites.

Added on a line in the middle of the list as the readme asks, to avoid merge conflicts.