### PR TITLE
Add klarbelegt.de and endearist.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -493,6 +493,7 @@ www.hackerspace.cl
 www.aylett.co.uk
 wronex.com
 strangereons.com
+klarbelegt.de
 kanoe.yuuko.eu
 wiki.postmarketos.org
 anita.garden
@@ -949,6 +950,7 @@ www.cvennevik.no
 freesteamtables.com
 linuxpréinstallé.com
 thermodynamique.fr
+endearist.com
 jacobfilipp.com
 birla.io
 kusoneko.moe


### PR DESCRIPTION
Two sites, both mine.

- **klarbelegt.de** — German federal and municipal statistics presented as charts, with the source and the date of the underlying data shown beside every figure. 171 cities and all 16 Bundesländer. No ads, no account, no cookies, no paywall. Per-indicator CSVs are published alongside, each carrying its source and licence.
- **endearist.com** — articles and free browser tools about relationships, friendship and self-knowledge, in English and German. Nothing needs an account.

Both entries were inserted at interior lines rather than appended, per the note at the bottom of `sites.txt`.