### PR TITLE
Add inspect.software

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -699,6 +699,7 @@ reykjalin.org
 aogavrilov.com
 links.bouncepaw.com
 saraf.iwl.pub
+inspect.software
 evrim.zone
 icanpathfinder.com
 mycorrhiza.wiki


### PR DESCRIPTION
Adds [inspect.software](https://inspect.software/) to the crawl list — my own site.

It publishes open-source health reports for public software packages: security, engineering quality, community adoption and maintenance vitality, scored from public signals and shown per package with the evidence behind each number. Static, no paywall, no login for the reports.

Added on a random line rather than at the end, per the note in `sites.txt`.