### PR TITLE
Add dreamingtogether.net to sites list

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -285,6 +285,7 @@ manualdousuario.net
 tuxilio.codeberg.page
 dewvintheshell.com
 secu.pages.dev
+dreamingtogether.net
 joeyshi.xyz
 robkohr.com
 himwant.org


### PR DESCRIPTION
Dreaming together is a small, independent site for an original novel. It is completely free with no adds or trackers!  