### PR TITLE
Add everydaycontentment.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -842,6 +842,7 @@ pastquestions.ng
 dvdnerd.neocities.org
 a-blue-in-a-sea-of-reds.neocities.org
 releases.bruta.link
+https://everydaycontentment.com
 www.cerealously.net
 bionicle.gay
 5min.ninja


### PR DESCRIPTION
Adds https://everydaycontentment.com to a random line per the instructions in sites.txt.

Human-written slow-living diary from Aotearoa New Zealand, publishing since January 2023. Non-commercial personal blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
