### PR TITLE
Add psychedex.org

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -1145,6 +1145,7 @@ www.timandraka.com
 ipv6buddy.com
 www.skeletonclaw.com
 sql-island.informatik.uni-kl.de
+psychedex.org
 michael-buschbeck.github.io
 rosenpass.eu
 cuiiliste.de


### PR DESCRIPTION
psychedex.org — a harm reduction encyclopedia: pharmacological reference data (dose tiers by route, interactions with severity, tolerance and dependency data), a 250+ entry effects taxonomy, and non-pharmacological practices. Text-oriented, no ads, no vendor content, no paywall on safety information. Every data value is traceable to a cited source.

Added at a random line per the note at the bottom of sites.txt.