### PR TITLE
Add Age Ayurveda Nighantu (Ayurvedic materia medica reference)

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -1317,6 +1317,7 @@ unitmeasure.xyz
 avi.is-a.dev
 sales.aviparshan.com
 akshitgaur2005.github.io
+https://jairaj1234-dancer.github.io/nighantu/
 http://bluepixelcomputing.com:8141/
 oxyn.org
 maxisodenoth.neocities.org


### PR DESCRIPTION
Adding https://jairaj1234-dancer.github.io/nighantu/

A free reference encyclopedia of Ayurvedic materia medica: 504 single-herb monographs, 143 classical formulations, 37 traditional instruments, and a practice guide to Shirodhara. Each entry opens with a plain definition, states identification and pharmacology as structured facts, cites the classical texts it draws on, and reports published research with dates.

Why it may suit Marginalia specifically:

- Static, no JavaScript at all, roughly 14 KB a page
- No advertising, no tracking, no sponsorship, no affiliate links
- Text-dense reference material rather than SEO content
- CC BY 4.0, with provenance stated openly, including what it derives from and where it is weakest
- Every page has a plain-Markdown twin at its URL with `.md` appended

Disclosure: the site is published by Age Ayurveda, which sells Ayurvedic products. That is stated on the site itself. Product links appear on about 15 of 779 pages, in one clearly labelled block at the foot of the page, and nowhere else.

Inserted at a random line per the note in `sites.txt`.