### PR TITLE
Add rodamora.com

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -713,6 +713,7 @@ www.stavros.io
 krishadi.com
 nichobi.com
 kypath.sdf.org
+rodamora.com
 fyndling.de
 tourdeniu.vonneudeck.com
 elnuevocreadortecnico.com


### PR DESCRIPTION
Adding my personal site to the crawl list.

rodamora.com is my own site: essays about where AI fits in a business that already has a team and processes, plus a glossary of the terms in plain English. English only, no ads, no trackers.

I put the line near the middle of the file as the readme asks.